### PR TITLE
Updated file sending and other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Requirements:
 
 ![summary_message](/docs/images/summary_message.png)
 
-#### Report file upload
-- If you have generated reports with the report plug in, and you have indicated the location of your Reports folder in the Slack Integration settings, any report files (html, csv, or pdf) found under the ID for test suites executed will be uploaded to the same Slack channel.
+#### Report file upload and channel(s) selection
+- You can send results to multiple channels by comma separating them in the Channel/Group text box.
+- If you have generated reports with the report plugin, and you have indicated the location of your Reports folder in the Slack Integration settings, by default the PDF report file found under the ID for test suites executed will be uploaded to the same Slack channel.
+- Optionally, appending .none, .csv, or .html to a channel name will instead send the respective file (none send only the text summary).
+- e.g. business_facing,results_summary.none,automation_debugging.html will send the suite results text summary to all 3 channels, and additionally send the PDF to the business_facing channel (since the PDFs are more human-readable), and the HTML report to the automation_debugging channel (since the HTML files expand further on details of failures). 
 - this requires the *files:write:user* scope for your app.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ Requirements:
 #### Report file upload and channel(s) selection
 - You can send results to multiple channels by comma separating them in the Channel/Group text box.
 - If you have generated reports with the report plugin, and you have indicated the location of your Reports folder in the Slack Integration settings, by default the PDF report file found under the ID for test suites executed will be uploaded to the same Slack channel.
-- Optionally, appending .none, .csv, or .html to a channel name will instead send the respective file (none send only the text summary).
-- e.g. business_facing,results_summary.none,automation_debugging.html will send the suite results text summary to all 3 channels, and additionally send the PDF to the business_facing channel (since the PDFs are more human-readable), and the HTML report to the automation_debugging channel (since the HTML files expand further on details of failures). 
+- Optionally, appending .none, .csv, or .html to a channel name will instead send the respective file (or none will send only the text summary).
+- e.g. business_facing_channel,results_summary_channel.none,automation_debugging_channel.html will send the suite results text summary to all 3 channels, and additionally send the PDF to business_facing_channel (since the PDFs are more human-readable and appropriate for a larger audience), and the HTML report to automation_debugging_channel (since the HTML files expand further on details of failures). 
 - this requires the *files:write:user* scope for your app.

--- a/src/main/java/com/katalon/plugin/slack/SlackEventListenerInitializer.java
+++ b/src/main/java/com/katalon/plugin/slack/SlackEventListenerInitializer.java
@@ -29,9 +29,7 @@ public class SlackEventListenerInitializer implements EventListenerInitializer, 
                 }
                 authToken = preferences.getString(SlackConstants.PREF_AUTH_TOKEN, "");
                 String channelsString = preferences.getString(SlackConstants.PREF_AUTH_CHANNEL, "");
-                System.out.println(channelsString);
                 String[] channelsArray = channelsString.split("\\s*,\\s*");
-                System.out.println(Arrays.toString(channelsArray) + "array " + channelsArray[0] + "1 " + channelsArray[1] + "2  Channels List*********************");
                 reportDir = preferences.getString(SlackConstants.PREF_REPORT_DIR, "");
                 if (ExecutionEvent.TEST_SUITE_FINISHED_EVENT.equals(event.getTopic())) {
                     for (String currentChannel : channelsArray) {
@@ -49,7 +47,6 @@ public class SlackEventListenerInitializer implements EventListenerInitializer, 
                             extension = "pdf";
                             channel = currentChannel;  
                         }
-                        System.out.println(channel + " Channel " + extension + " extension");
                         ExecutionEvent eventObject = (ExecutionEvent) event.getProperty("org.eclipse.e4.data");
 
                         TestSuiteExecutionContext testSuiteContext = (TestSuiteExecutionContext) eventObject
@@ -119,10 +116,9 @@ public class SlackEventListenerInitializer implements EventListenerInitializer, 
                     String fileName = FilenameUtils.getBaseName(child.getName());
                     String contextId = context.getId();
                     String ext = FilenameUtils.getExtension(child.getName());
-                    System.out.println(fileName + " File Name + " + contextId + " context ID " + ext + " ext " + authToken + " Auth token");
                     if (ext.equals(extension) && contextId.equals(fileName)) {
                         SlackUtil.sendFile(authToken, channel, context.getSourceId(), context.getId(), child);
-                        System.out.println("Slack: Summary attachment message has been successfully sent");  
+                        System.out.println("Slack: Summary attachment file has been successfully sent to channel: " + channel);  
                     }
                 }
             }

--- a/src/main/java/com/katalon/plugin/slack/SlackPreferencePage.java
+++ b/src/main/java/com/katalon/plugin/slack/SlackPreferencePage.java
@@ -25,7 +25,9 @@ public class SlackPreferencePage extends PreferencePage implements SlackComponen
 
     private Button chckEnableIntegration;
 
-    private Group grpAuthentication;
+    private Group grpSettings;
+
+    private Group grpHelpText;
 
     private Text txtToken;
 
@@ -49,39 +51,39 @@ public class SlackPreferencePage extends PreferencePage implements SlackComponen
         chckEnableIntegration = new Button(container, SWT.CHECK);
         chckEnableIntegration.setText("Using Slack");
 
-        grpAuthentication = new Group(container, SWT.NONE);
-        grpAuthentication.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
-        GridLayout glAuthentication = new GridLayout(2, false);
-        glAuthentication.horizontalSpacing = 15;
-        glAuthentication.verticalSpacing = 10;
-        grpAuthentication.setLayout(glAuthentication);
-        grpAuthentication.setText("Authentication");
+        grpSettings = new Group(container, SWT.NONE);
+        grpSettings.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
+        GridLayout glSettings = new GridLayout(2, false);
+        glSettings.horizontalSpacing = 15;
+        glSettings.verticalSpacing = 10;
+        grpSettings.setLayout(glSettings);
+        grpSettings.setText("Settings");
 
-        Label lblToken = new Label(grpAuthentication, SWT.NONE);
+        Label lblToken = new Label(grpSettings, SWT.NONE);
         lblToken.setText("Authentication Token");
         GridData gdLabel = new GridData(SWT.LEFT, SWT.TOP, false, false);
         lblToken.setLayoutData(gdLabel);
 
-        txtToken = new Text(grpAuthentication, SWT.BORDER);
+        txtToken = new Text(grpSettings, SWT.BORDER);
         GridData gdTxtToken = new GridData(SWT.FILL, SWT.CENTER, true, false);
         gdTxtToken.widthHint = 200;
         txtToken.setLayoutData(gdTxtToken);
 
-        Label lblChannel = new Label(grpAuthentication, SWT.NONE);
+        Label lblChannel = new Label(grpSettings, SWT.NONE);
         lblChannel.setText("Channel/Group");
         lblToken.setLayoutData(gdLabel);
 
-        txtChannel = new Text(grpAuthentication, SWT.BORDER);
+        txtChannel = new Text(grpSettings, SWT.BORDER);
         txtChannel.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
 
-        Label lblReport = new Label(grpAuthentication, SWT.NONE);
+        Label lblReport = new Label(grpSettings, SWT.NONE);
         lblReport.setText("Report Folder (empty = no upload)");
         lblReport.setLayoutData(gdLabel);
 
-        txtReport = new Text(grpAuthentication, SWT.BORDER);
+        txtReport = new Text(grpSettings, SWT.BORDER);
         txtReport.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
 
-        btnTestConnection = new Button(grpAuthentication, SWT.PUSH);
+        btnTestConnection = new Button(grpSettings, SWT.PUSH);
         btnTestConnection.setText("Test Connection");
         btnTestConnection.addSelectionListener(new SelectionAdapter() {
             @Override
@@ -89,10 +91,24 @@ public class SlackPreferencePage extends PreferencePage implements SlackComponen
                 testSlackConnection(txtToken.getText(), txtChannel.getText());
             }
         });
+     
 
-        lblConnectionStatus = new Label(grpAuthentication, SWT.NONE);
+        lblConnectionStatus = new Label(grpSettings, SWT.NONE);
         lblConnectionStatus.setText("");
         lblConnectionStatus.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, true, 1, 1));
+
+
+        grpHelpText = new Group(container, SWT.NONE);
+        grpHelpText.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
+        GridLayout glHelpText = new GridLayout(2, false);
+        glHelpText.horizontalSpacing = 15;
+        glHelpText.verticalSpacing = 10;
+        grpHelpText.setLayout(glHelpText);
+        grpHelpText.setText("Help");
+
+        Label helpText = new Label(grpHelpText, SWT.NONE);
+        helpText.setText("Comma separate channels to send to multiple channels. \nBy default, the PDF report will be uploaded. To change which file sends for specific\nchannels, append .none or .html.\n e.g. automation-results,automation-report-summary.none,automation-debug.html \nwill send the PDF to the first channel, only the text results to the second, and the\nHTML file to the third.");
+        helpText.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, true, 1, 1));   
 
         handleControlModifyEventListeners();
         initializeInput();
@@ -140,7 +156,7 @@ public class SlackPreferencePage extends PreferencePage implements SlackComponen
         chckEnableIntegration.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
-                recursiveSetEnabled(grpAuthentication, chckEnableIntegration.getSelection());
+                recursiveSetEnabled(grpSettings, chckEnableIntegration.getSelection());
             }
         });
     }


### PR DESCRIPTION
Added ability to send to multiple channels by comma separating them in the Channel/Group text box. 
Updated file sending to default to sending the PDF, and to also be configurable on a per-channel basis, see readme.
Updated formatting of the text summary sent. 